### PR TITLE
Add Rubinius to Build Matrix with Allowed Failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.0
+  - rbx-2
+matrix:
+  allow_failures:
+    - rvm: rbx-2
 
 gemfile:
   - test/gemfiles/1.0


### PR DESCRIPTION
Please add Rubinius to the build matrix with failure allowed.

I am trying to add this to ensure this Gem works in Rubinius and to complete this dashboard: http://bjfish.github.io/rubinius-gem-build-status/page2/.